### PR TITLE
#260 Fix NPE when LiteralNumericValue has no value

### DIFF
--- a/docgenhtml/plugins/org.polarsys.capella.docgen/src/org/polarsys/capella/docgen/util/CapellaDataValueServices.java
+++ b/docgenhtml/plugins/org.polarsys.capella.docgen/src/org/polarsys/capella/docgen/util/CapellaDataValueServices.java
@@ -342,8 +342,10 @@ public class CapellaDataValueServices {
 		// Test the type of the Data Value
 		if (dataValue_p instanceof LiteralNumericValue) 
 		{
-			// Return the value
-			return (((LiteralNumericValue) dataValue_p).getValue());
+      String value = ((LiteralNumericValue) dataValue_p).getValue();
+      if (value == null) {
+        return CapellaServices.UNDEFINED_CHEVRON;
+      }
 		} 
 		else 
 		{

--- a/tests/plugins/org.polarsys.capella.docgen.test.ju/model/In-Flight Entertainment System/In-Flight Entertainment System.capella
+++ b/tests/plugins/org.polarsys.capella.docgen.test.ju/model/In-Flight Entertainment System/In-Flight Entertainment System.capella
@@ -808,6 +808,8 @@
           id="9e7dc154-82fe-46f0-9448-9d03adc75ee2" name="Interfaces"/>
       <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
           id="be6614b7-9512-4113-b3bc-76a3b7e01a4e" name="Data">
+        <ownedDataValues xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+            id="889c2c29-99f1-4c8c-990a-0f7530d9ab4d" name="LiteralNumericValue 1"/>
         <ownedDataPkgs xsi:type="org.polarsys.capella.core.data.information:DataPkg"
             id="25fe63b8-424c-492e-918c-835cafd785b5" name="Classes"/>
         <ownedStateEvents xsi:type="org.polarsys.capella.core.data.capellacommon:ChangeEvent"


### PR DESCRIPTION
Change-Id: Ib482cc69ae9b0444bf57bf4babcd9e58ca4e5168